### PR TITLE
Relax node version to allow easier installs elsewhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "storybook:build": "build-storybook -c .storybook -o dist",
     "storybook:start": "start-storybook -p 54321 --ci"
   },
+  "dependencies": {
+    "prettier-stylelint": "^0.4.2"
+  },
   "devDependencies": {
     "@babel/core": "^7.10.2",
     "@babel/plugin-proposal-class-properties": "^7.10.1",
@@ -96,12 +99,9 @@
   },
   "keywords": [],
   "engines": {
-    "node": "12.18.1"
+    "node": "^12.18.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
-  },
-  "dependencies": {
-    "prettier-stylelint": "^0.4.2"
   }
 }


### PR DESCRIPTION
The current version  is [12.18.2](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.18.2) and relaxing the version here would allow easier Docker container builds in other projects.

I've used the [caret](https://docs.npmjs.com/cli-commands/update.html#caret-dependencies) operator here so we track the LTS 12.x branch, which is what the current node 12 docker containers/packages would track.