### PR TITLE
Update link primitive

### DIFF
--- a/src/elements/text-content/_p.scss
+++ b/src/elements/text-content/_p.scss
@@ -3,7 +3,6 @@
 
 p {
   @include margin.b('bee');
-  @include type.primitive;
-
   max-width: 50ch;
+  @include type.primitive;
 }

--- a/src/primitives/_link.scss
+++ b/src/primitives/_link.scss
@@ -1,11 +1,9 @@
 @use 'src/mixins/margin';
 @use 'src/mixins/type-scale';
-@use 'src/tokens/font-weight';
 @use 'src/tokens/transition-timing';
 @use 'src/tokens/transition-duration';
 
 @mixin primitive {
-  font-weight: font-weight.$regular;
   text-decoration: underline;
   text-decoration-skip-ink: auto;
   transition-duration: transition-duration.$short;


### PR DESCRIPTION
Removes the font-weight from links. A link should respect the font-weight of the text it's contained within.