### PR TITLE
Fix image block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpf/sauce",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://sauce.raspberrypi.org",
   "repository": "github:RaspberryPiFoundation/sauce-design-system",
   "bugs": "https://github.com/RaspberryPiFoundation/sauce-design-system/issues",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "main": "src/index.js",
   "files": [
     "lib",

--- a/src/components/raspberry-pi/image-block/_index.scss
+++ b/src/components/raspberry-pi/image-block/_index.scss
@@ -1,32 +1,6 @@
 @use 'src/mixins/device';
 @use 'src/mixins/padding';
 
-@mixin unsafe-debug {
-  @warn 'PLEASE REMOVE ALL DEBUG INCLUDES BEFORE DEPLOYING TO PRODUCTION';
-
-  .sc-rp-image-block--debug & {
-    @content;
-  }
-}
-
-@mixin image-bottom {
-  .sc-rp-image-block--image-bottom & {
-    @content;
-  }
-}
-
-@mixin image-top {
-  .sc-rp-image-block--image-top & {
-    @content;
-  }
-}
-
-@mixin reverse {
-  .sc-rp-image-block--reverse & {
-    @content;
-  }
-}
-
 .sc-rp-image-block {
   align-items: center;
   display: flex;
@@ -47,33 +21,16 @@
   }
 }
 
-.sc-rp-image-block--reverse {
-  flex-direction: column-reverse;
-
-  @include device.min-width(760px) {
-    flex-direction: row-reverse;
-  }
-}
-
 .sc-rp-image-block__content {
   @include padding.l([ 'bee', 'grizzly' ]);
   @include padding.r([ 'bee', 'ant' ]);
   @include padding.block('dog');
   width: 100%;
 
-  @include reverse {
-    @include padding.l([ 'bee', 'ant' ]);
-    @include padding.r([ 'bee', 'grizzly' ]);
-  }
-
   @include device.min-width(760px) {
     grid-column: 1 / 4;
     grid-row: 1 / 2;
     z-index: 1;
-
-    @include reverse {
-      grid-column: 3 / 5;
-    }
   }
 }
 
@@ -86,18 +43,6 @@
     grid-row: 1 / 2;
     justify-content: flex-end;
     max-width: 100%;
-
-    @include image-bottom {
-      align-self: flex-end;
-    }
-
-    @include image-top {
-      align-self: flex-start;
-    }
-
-    @include reverse {
-      grid-column: 1 / 4;
-    }
   }
 }
 
@@ -108,7 +53,63 @@
   transform: translateX(-18.75%);
   width: 160%;
 
-  @include unsafe-debug {
+  @include device.min-width(760px) {
+    transform: translateX(0%);
+    width: 100%;
+  }
+}
+
+.sc-rp-image-block__image {
+  display: block;
+  height: auto;
+  width: 100%;
+}
+
+/* MODIFIERS */
+
+.sc-rp-image-block--image-bottom {
+  .sc-rp-image-block__figure {
+    @include device.min-width(760px) {
+      align-self: flex-end;
+    }
+  }
+}
+
+.sc-rp-image-block--image-top {
+  .sc-rp-image-block__figure {
+    @include device.min-width(760px) {
+      align-self: flex-start;
+    }
+  }
+}
+
+.sc-rp-image-block--reverse {
+  flex-direction: column-reverse;
+
+  @include device.min-width(760px) {
+    flex-direction: row-reverse;
+  }
+
+  .sc-rp-image-block__content {
+    @include padding.l([ 'bee', 'ant' ]);
+    @include padding.r([ 'bee', 'grizzly' ]);
+
+    @include device.min-width(760px) {
+      grid-column: 3 / 5;
+    }
+  }
+
+  .sc-rp-image-block__figure {
+    @include device.min-width(760px) {
+      grid-column: 1 / 4;
+    }
+  }
+}
+
+/* DEBUG */
+
+.sc-rp-image-block--debug {
+  .sc-rp-image-block__image-container {
     position: relative;
 
     &::after,
@@ -139,15 +140,4 @@
       transform: rotateY(180deg);
     }
   }
-
-  @include device.min-width(760px) {
-    transform: translateX(0%);
-    width: 100%;
-  }
-}
-
-.sc-rp-image-block__image {
-  display: block;
-  height: auto;
-  width: 100%;
 }

--- a/src/components/raspberry-pi/image-block/index.stories.mdx
+++ b/src/components/raspberry-pi/image-block/index.stories.mdx
@@ -51,9 +51,9 @@ In the following examples you can see the quiet area on the images illustrated w
     </div>
     <div class="sc-rp-image-block__figure">
       <picture class="sc-rp-image-block__image-container">
-        <source srcset={christinaSm} />
-        <source media="(min-width: 600px)" srcset={christinaMd} />
         <source media="(min-width: 1000px)" srcset={christinaLg} />
+        <source media="(min-width: 600px)" srcset={christinaMd} />
+        <source srcset={christinaSm} />
         <img
           alt="Christina Foust, from Raspberry Pi Foundation North America"
           class="sc-rp-image-block__image"
@@ -87,11 +87,11 @@ In the following examples you can see the quiet area on the images illustrated w
     </div>
     <div class="sc-rp-image-block__figure">
       <picture class="sc-rp-image-block__image-container">
-        <source srcset={coolestProjectsSm} />
-        <source media="(min-width: 600px)" srcset={coolestProjectsMd} />
         <source media="(min-width: 1000px)" srcset={coolestProjectsLg} />
+        <source media="(min-width: 600px)" srcset={coolestProjectsMd} />
+        <source srcset={coolestProjectsSm} />
         <img
-          alt="A Makers shows her creation at Coolest Project International 2019"
+          alt="A Maker shows her creation at Coolest Project International 2019"
           class="sc-rp-image-block__image"
           height="800"
           src={coolestProjectsMd}


### PR DESCRIPTION
Image block picture source elements were in the wrong order in the docs.

Also, the image block modifier selectors were using Sass's `&` selector:

```scss
.sc-rp-image-block__content {
  .sc-rp-image-block--reverse & {
    ...
  }
}
```

We're currently forced to implement Sauce on the JAMstack like this:

```scss
.sauce {
  ...
  @import '~@rpf/sauce/src/components/raspberry-pi/image-block';
  ...
}
```

Which results in the following CSS:

```css
.sc-rp-image-block--reverse .sauce .sc-rp-image-block__content {
  ...
}
```

I've updated the structure for the modifiers to omit the `&` selector. Which will result in the correct selector formation when fed through the `.sauce` namespace.