### PR TITLE
Horizontal scroll bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpf/sauce",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://sauce.raspberrypi.org",
   "repository": "github:RaspberryPiFoundation/sauce-design-system",
   "bugs": "https://github.com/RaspberryPiFoundation/sauce-design-system/issues",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "main": "src/index.js",
   "files": [
     "lib",

--- a/src/elements/main-root/_html.scss
+++ b/src/elements/main-root/_html.scss
@@ -3,8 +3,5 @@
 html {
   background-color: color-greyscale.$white;
   font-size: 62.5%;
-  max-width: 100vw;
   min-height: 100vh;
-  min-width: 100vw;
-  width: 100vw;
 }

--- a/src/elements/main-root/_html.scss
+++ b/src/elements/main-root/_html.scss
@@ -3,5 +3,4 @@
 html {
   background-color: color-greyscale.$white;
   font-size: 62.5%;
-  min-height: 100vh;
 }

--- a/src/elements/sectioning-root/_body.scss
+++ b/src/elements/sectioning-root/_body.scss
@@ -7,7 +7,6 @@
 
 body {
   @include type-scale.skateboard;
-
   background-color: color-greyscale.$white;
   color: color-greyscale.$off-black;
   font-display: swap;
@@ -15,13 +14,10 @@ body {
   font-variant-ligatures: none;
   font-weight: font-weight.$regular;
   line-height: line-height.$regular;
-  max-width: 100vw;
   min-height: 100vh;
-  min-width: 100vw;
   padding: env(safe-area-inset-top) env(safe-area-inset-right)
     env(safe-area-inset-bottom) env(safe-area-inset-left);
   position: relative;
   text-rendering: optimizeLegibility;
   text-size-adjust: 100%;
-  width: 100vw;
 }

--- a/src/elements/sectioning-root/_body.scss
+++ b/src/elements/sectioning-root/_body.scss
@@ -14,7 +14,6 @@ body {
   font-variant-ligatures: none;
   font-weight: font-weight.$regular;
   line-height: line-height.$regular;
-  min-height: 100vh;
   padding: env(safe-area-inset-top) env(safe-area-inset-right)
     env(safe-area-inset-bottom) env(safe-area-inset-left);
   position: relative;


### PR DESCRIPTION
Closes #33 

Removes `width`, `min-width`, `max-width`, and `min-height` from the `<html>` and `<body>` elements. The styles were causing horizontal scroll if the user's browser has permanently visible scrollbars.