### PR TITLE
Remove warnings

### DIFF
--- a/lib/_type-scale.scss
+++ b/lib/_type-scale.scss
@@ -17,7 +17,7 @@ $scale: (
 );
 
 @mixin output($sizes) {
-  @include warn.careful('Maybe take a look at the new font-size mixins file?');
+  // @include warn.careful('Maybe take a look at the new font-size mixins file?');
   @include responsive-values.output(
     'font-size',
     responsive-values.map($base-sizes, $scale, $sizes)

--- a/lib/_value.scss
+++ b/lib/_value.scss
@@ -9,12 +9,14 @@
   }
 }
 
-@mixin clamp($property, $tokens) {
-  @include fixed($property, $tokens);
+@mixin clamp($property, $tokens, $with-fixed: true) {
+  @if ($with-fixed) {
+    @include fixed($property, $tokens);
+  }
 
   @if (meta.type-of($property) == 'list') {
     @each $sub-property in $property {
-      @include clamp($sub-property, $tokens);
+      @include clamp($sub-property, $tokens, $with-fixed: false);
     }
   } @else {
     $clamp-values: map-get($tokens, clamp);

--- a/src/layouts/container/_index.scss
+++ b/src/layouts/container/_index.scss
@@ -1,7 +1,7 @@
 @use 'src/mixins/layouts';
 @use 'lib/warn';
 
-@include warn.careful('We might stop using this in favor of the layouts.container and layouts.block mixin');
+// @include warn.careful('We might stop using this in favor of the layouts.container and layouts.block mixin');
 
 .sl-container {
   @include layouts.container;

--- a/src/layouts/section/_index.scss
+++ b/src/layouts/section/_index.scss
@@ -1,7 +1,7 @@
 @use 'src/mixins/layouts';
 @use 'lib/warn';
 
-@include warn.careful('We might stop using this in favor of the layouts.slice mixin');
+// @include warn.careful('We might stop using this in favor of the layouts.slice mixin');
 
 .sl-section {
   @include layouts.slice;

--- a/src/mixins/_margin.scss
+++ b/src/mixins/_margin.scss
@@ -10,7 +10,7 @@
 }
 
 @mixin h($sizes) {
-  @include warn.deprecated('Use margin.inline instead');
+  // @include warn.deprecated('Use margin.inline instead');
   @include inline($sizes);
 }
 
@@ -24,7 +24,7 @@
 }
 
 @mixin v($sizes) {
-  @include warn.deprecated('Use margin.block instead');
+  // @include warn.deprecated('Use margin.block instead');
   @include block($sizes);
 }
 

--- a/src/mixins/_padding.scss
+++ b/src/mixins/_padding.scss
@@ -10,7 +10,7 @@
 }
 
 @mixin h($sizes) {
-  @include warn.deprecated('Use padding.inline instead');
+  // @include warn.deprecated('Use padding.inline instead');
   @include inline($sizes);
 }
 
@@ -24,7 +24,7 @@
 }
 
 @mixin v($sizes) {
-  @include warn.deprecated('Use padding.block instead');
+  // @include warn.deprecated('Use padding.block instead');
   @include block($sizes);
 }
 


### PR DESCRIPTION
Remove "careful" and "deprecation" warnings.

Also solves an issue when the "fixed" versions of styles would be output multiple times when setting clamped values for multiple properties.