### PR TITLE
Make design system variables available inside web component

### DIFF
--- a/scss/properties/_border-radius.scss
+++ b/scss/properties/_border-radius.scss
@@ -1,4 +1,4 @@
-:root {
+:root, :host {
   --border-radius-circle: 50%;
   --border-radius-large: 1rem;
   --border-radius-medium: 0.5rem;

--- a/scss/properties/_border-width.scss
+++ b/scss/properties/_border-width.scss
@@ -1,4 +1,4 @@
-:root {
+:root, :host {
   --border-width-none: 0;
   --border-width-narrow: 0.1rem;
   --border-width-medium: 0.2rem;

--- a/scss/properties/_font-family.scss
+++ b/scss/properties/_font-family.scss
@@ -1,4 +1,4 @@
-:root {
+:root, :host {
   --font-family-heading: serif;
   --font-family-monospace: monospace;
   --font-family-sans-serif: sans-serif;

--- a/scss/properties/_font-size.scss
+++ b/scss/properties/_font-size.scss
@@ -22,7 +22,7 @@ $_d-1: math.pow($_r, -1) * $_b; // 0.833rem == 13.33px
 $_d-2: math.pow($_r, -2) * $_b; // 0.694rem == 11.11px
 $_d-3: math.pow($_r, -3) * $_b; // 0.579rem == 9.26px
 
-:root {
+:root, :host {
   --font-size-base: #{$_b};
   --font-size-ratio: #{$_r};
   --font-size-u-8: #{$_u-8};

--- a/scss/properties/_font-weight.scss
+++ b/scss/properties/_font-weight.scss
@@ -1,4 +1,4 @@
-:root {
+:root, :host {
   --font-weight-light: 300;
   --font-weight-regular: 400;
   --font-weight-medium: 500;

--- a/scss/properties/_line-height.scss
+++ b/scss/properties/_line-height.scss
@@ -1,4 +1,4 @@
-:root {
+:root, :host {
   --line-height-reset: 1;
   --line-height-tight: 1.1;
   --line-height-cosy: 1.2;

--- a/scss/properties/_spacing.scss
+++ b/scss/properties/_spacing.scss
@@ -1,4 +1,4 @@
-:root {
+:root, :host {
   --spacing-multiplier: 0.625;
   --spacing-0: 0;
   --spacing-1: calc(1rem * var(--spacing-multiplier)); // 0.625rem

--- a/scss/properties/_transition-duration.scss
+++ b/scss/properties/_transition-duration.scss
@@ -1,4 +1,4 @@
-:root {
+:root, :host {
   --transition-duration-instantly: 0s;
   --transition-duration-immediately: 0.05s;
   --transition-duration-quickly: 0.1s;

--- a/scss/properties/_transition-timing.scss
+++ b/scss/properties/_transition-timing.scss
@@ -1,4 +1,4 @@
-:root {
+:root, :host {
   --transition-timing-eased: ease-in-out;
   --transition-timing-elastic: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }

--- a/scss/properties/color/_greyscale.scss
+++ b/scss/properties/color/_greyscale.scss
@@ -1,4 +1,4 @@
-:root {
+:root, :host {
   // Black/White
   --black: #000;
   --white: #fff;


### PR DESCRIPTION
# What's Changed?

Modified the `scss` files defining variables to include the `:host` selector as well as `:root`. This allows the variables to be accessed inside a web component shadow DOM that includes the relevant stylesheet. C.f. the docs for [:host](https://developer.mozilla.org/en-US/docs/Web/CSS/:host).